### PR TITLE
Add Claude Code global settings to dotfiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ dotfiles/
 ├── dev/        # .pypirc, .isort.cfg, .node-version, .psqlrc
 ├── ruby/       # .irbrc, .gemrc, .rspec
 ├── misc/       # .hgrc
+├── claude/     # settings.json → ~/.claude/settings.json (global Claude Code settings)
+├── .claude/    # settings.local.json (project-level overrides for this repo only)
 ├── install.sh  # creates symlinks to $HOME
 └── Makefile    # install/uninstall targets
 ```

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,5 @@ uninstall:
 	@rm -f ~/.hgrc
 	@rm -f ~/.docker/desktop/backend.sock
 	@rm -f ~/.config/opencode/opencode.json
+	@rm -f ~/.claude/settings.json
 	@echo "Dotfiles uninstalled!"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch:*)",
+      "Bash(git add:*)",
+      "Bash(git push:*)",
+      "Bash(gh:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(pytest:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(uv:*)",
+      "Bash(poetry:*)",
+      "Bash(ruff:*)",
+      "Bash(mypy:*)",
+      "Bash(black:*)",
+      "Bash(isort:*)",
+      "Bash(make:*)"
+    ]
+  },
+  "cleanupPeriodDays": 30
+}

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,11 @@ if [[ -d "${HOME}/.config/opencode" ]]; then
     safe_ln "$DOTFILES_DIR/opencode/opencode.json" "$HOME/.config/opencode/opencode.json" "opencode.json" || true
 fi
 
+# Claude Code settings.
+echo "- Linking Claude Code settings..."
+mkdir -p "${HOME}/.claude"
+safe_ln "$DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json" "claude settings.json" || true
+
 # Docker Desktop MCP Toolkit symlink for WSL
 if grep -qi microsoft /proc/version 2>/dev/null; then
     echo "- Detected WSL environment..."


### PR DESCRIPTION
## Summary

- Adds `claude/settings.json` with sane defaults for a Python developer, managed alongside the rest of the dotfiles
- Updates `install.sh` to symlink `~/.claude/settings.json` → `dotfiles/claude/settings.json`
- Updates `Makefile` uninstall target to remove the symlink on teardown
- Documents the new `claude/` and `.claude/` directories in `CLAUDE.md`

## Details

### `claude/settings.json`

Pre-approves common Python dev tools so Claude Code doesn't prompt on every run:

- **Python runtime**: `python`, `python3`
- **Testing**: `pytest`
- **Package managers**: `pip`, `pip3`, `uv`, `poetry`
- **Linting/formatting**: `ruff`, `mypy`, `black`, `isort`
- **Build**: `make`
- **Git/GitHub**: `git fetch`, `git add`, `git push`, `gh` CLI

Also sets `cleanupPeriodDays: 30` to retain conversation history for a month.

`git commit` is intentionally **not** pre-approved — commits should remain deliberate.

### Directory distinction

| Path | Purpose |
|------|---------|
| `claude/settings.json` | Global user settings → `~/.claude/settings.json` |
| `.claude/settings.local.json` | Project-level overrides active only inside this repo |