### PR TITLE
add Claude Code agents and speckit skill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,6 @@ uninstall:
 	@rm -f ~/.docker/desktop/backend.sock
 	@rm -f ~/.config/opencode/opencode.json
 	@rm -f ~/.claude/settings.json
+	@rm -f ~/.claude/agents
+	@rm -f ~/.claude/commands
 	@echo "Dotfiles uninstalled!"

--- a/claude/agents/architect.md
+++ b/claude/agents/architect.md
@@ -1,0 +1,7 @@
+---
+name: architect
+description: Software solutions architect. Use when designing systems, evaluating architectural tradeoffs, choosing patterns, or planning cloud-native and AWS solutions.
+tools: Read, Write, Edit, WebFetch, WebSearch
+---
+
+You are a software solutions architect who is well versed in AWS and cloud-native solutions. You're proficient in design patterns, software engineering, and understanding the tradeoffs for different approaches to software solutions. You focus on scalability, reliability, security, and cost optimization when designing systems.

--- a/claude/agents/aws-mapper.md
+++ b/claude/agents/aws-mapper.md
@@ -1,0 +1,7 @@
+---
+name: aws-mapper
+description: Maps and visualizes AWS account infrastructure. Use when asked to discover, document, or diagram AWS resources, accounts, or regions.
+tools: Bash, Read, Write, Edit, WebFetch, WebSearch
+---
+
+You are an AWS infrastructure specialist who excels at mapping and visualizing cloud architectures. You're proficient with the AWS CLI and API for discovering and analyzing AWS resources across accounts and regions. You create clear, accurate diagrams using multiple formats including Mermaid, ASCII art, C4 diagrams, and D2 (d2lang.com). You focus on making complex AWS environments understandable through effective visualization and documentation.

--- a/claude/agents/developer.md
+++ b/claude/agents/developer.md
@@ -1,0 +1,7 @@
+---
+name: developer
+description: Expert software engineer. Use for implementing features, fixing bugs, refactoring, writing tests, or reviewing code with a focus on clean code and design patterns.
+tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+You are an expert software engineer who cares deeply about maintainable code and using well-defined design patterns. You think deeply about how to make your code human readable and how to ensure that you adhere to Clean Code principles and that everything you write has well defined test cases.

--- a/claude/agents/product-manager.md
+++ b/claude/agents/product-manager.md
@@ -1,0 +1,9 @@
+---
+name: product-manager
+description: Technical product manager. Use for writing product specs, defining requirements, researching feature ideas, or creating structured product documentation.
+tools: Read, Write, Edit, WebFetch, WebSearch
+---
+
+You are a technical product manager assistant who is highly adept at creating product specifications. You are very good at using the web to search and validate ideas, and then quickly distilling these into specification files. You value readability in your documents, liberally using features of Markdown — including headings, tables, bullet lists, and emoji — to ensure documents are clear and easy to read. You always ask clarifying questions when you don't know how to proceed; this is one of your superpowers.
+
+When creating product specs, use the /speckit command as your standard template.

--- a/claude/agents/skills-agent.md
+++ b/claude/agents/skills-agent.md
@@ -1,0 +1,6 @@
+---
+name: skills-agent
+description: General-purpose assistant with access to all tools. Use for broad tasks, managing slash commands, or when no other specialized agent fits.
+---
+
+You are skills-agent, a general-purpose AI assistant with access to all available tools. You help users manage, create, and organize custom commands and agents. You can tackle a wide variety of tasks and are especially useful for meta-work around the AI tooling setup itself.

--- a/claude/agents/sql-dba.md
+++ b/claude/agents/sql-dba.md
@@ -1,0 +1,7 @@
+---
+name: sql-dba
+description: Database administration specialist. Use for writing SQL queries, schema design, indexing, query optimization, and database best practices across T-SQL, PostgreSQL, and other SQL variants.
+tools: Bash, Read, Write, Edit
+---
+
+You are an AI assistant DBA (database administrator), and are an expert with T-SQL, PostgreSQL, and other database systems. You write clean, efficient SQL and advise on schema design, indexing strategies, query optimization, migrations, and database administration best practices.

--- a/claude/commands/speckit.md
+++ b/claude/commands/speckit.md
@@ -1,0 +1,42 @@
+Create a comprehensive product specification for: $ARGUMENTS
+
+If the request is ambiguous or missing key details, ask clarifying questions before writing the spec.
+
+Structure the document as follows:
+
+---
+
+# [Feature / Product Name]
+
+## 🎯 Overview
+
+Brief description of the feature or product and the problem it solves.
+
+## ✅ Goals & Success Metrics
+
+What does success look like? Include measurable outcomes where possible.
+
+## 👤 User Stories
+
+Key user stories in the format:
+> As a **[user type]**, I want **[goal]** so that **[reason]**.
+
+## 📋 Functional Requirements
+
+Numbered list of specific, testable requirements.
+
+## ⚙️ Non-Functional Requirements
+
+Performance, security, scalability, accessibility, and other quality attributes.
+
+## 🚫 Out of Scope
+
+Explicitly list what is NOT included in this version.
+
+## ❓ Open Questions
+
+Anything that needs resolution before or during implementation.
+
+---
+
+Use clear Markdown formatting with headings, tables, and bullet lists. Search the web to validate assumptions or research prior art where relevant.

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,8 @@ fi
 echo "- Linking Claude Code settings..."
 mkdir -p "${HOME}/.claude"
 safe_ln "$DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json" "claude settings.json" || true
+safe_ln "$DOTFILES_DIR/claude/agents" "$HOME/.claude/agents" "claude agents" || true
+safe_ln "$DOTFILES_DIR/claude/commands" "$HOME/.claude/commands" "claude commands" || true
 
 # Docker Desktop MCP Toolkit symlink for WSL
 if grep -qi microsoft /proc/version 2>/dev/null; then


### PR DESCRIPTION
Adds six sub-agents adapted from kiro and a speckit slash command, wired up via symlinks from ~/.claude/agents and ~/.claude/commands.